### PR TITLE
imp: use errorsmod throughout repo

### DIFF
--- a/controller/adapter/ibc.go
+++ b/controller/adapter/ibc.go
@@ -22,8 +22,8 @@ package adapter
 
 import (
 	"context"
-	"fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
@@ -59,7 +59,7 @@ func NewIBCAdapter(cdc codec.Codec, logger log.Logger) (*IBCAdapter, error) {
 
 	parser, err := NewIBCParser(cdc)
 	if err != nil {
-		return nil, fmt.Errorf("error during instantiation of IBC adapter: %w", err)
+		return nil, errorsmod.Wrap(err, "error during instantiation of IBC adapter")
 	}
 
 	return &IBCAdapter{

--- a/controller/forwarding/cctp_test.go
+++ b/controller/forwarding/cctp_test.go
@@ -129,7 +129,7 @@ func TestHandlePacket(t *testing.T) {
 			},
 		},
 		{
-			name: "error - cctp server returns an error",
+			name: "error - CCTP server returns an error",
 			setup: func() context.Context {
 				return context.WithValue(context.Background(), mocks.FailingContextKey, true)
 			},

--- a/depinject.go
+++ b/depinject.go
@@ -21,14 +21,13 @@
 package orbiter
 
 import (
-	"fmt"
-
 	cctpkeeper "github.com/circlefin/noble-cctp/x/cctp/keeper"
 
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -115,7 +114,7 @@ func InjectOrbitControllers(in ComponentsInputs) {
 		cctpkeeper.NewMsgServerImpl(in.CCTPKeeper),
 	)
 	if err != nil {
-		panic(fmt.Errorf("error creating cctp controller: %w", err))
+		panic(errorsmod.Wrap(err, "error creating cctp controller"))
 	}
 
 	in.Orbiters.SetForwardingControllers(cctp)
@@ -127,7 +126,7 @@ func InjectActionControllers(in ComponentsInputs) {
 		in.BankKeeper,
 	)
 	if err != nil {
-		panic(fmt.Errorf("error creating fee controller: %w", err))
+		panic(errorsmod.Wrap(err, "error creating fee controller"))
 	}
 
 	in.Orbiters.SetActionControllers(fee)
@@ -139,7 +138,7 @@ func InjectAdapterControllers(in ComponentsInputs) {
 		in.Orbiters.Adapter().Logger(),
 	)
 	if err != nil {
-		panic(fmt.Errorf("error creating ibc adapter: %w", err))
+		panic(errorsmod.Wrap(err, "error creating ibc adapter"))
 	}
 
 	in.Orbiters.SetAdapterControllers(ibc)

--- a/depinject.go
+++ b/depinject.go
@@ -114,7 +114,7 @@ func InjectOrbitControllers(in ComponentsInputs) {
 		cctpkeeper.NewMsgServerImpl(in.CCTPKeeper),
 	)
 	if err != nil {
-		panic(errorsmod.Wrap(err, "error creating cctp controller"))
+		panic(errorsmod.Wrap(err, "error creating CCTP controller"))
 	}
 
 	in.Orbiters.SetForwardingControllers(cctp)
@@ -138,7 +138,7 @@ func InjectAdapterControllers(in ComponentsInputs) {
 		in.Orbiters.Adapter().Logger(),
 	)
 	if err != nil {
-		panic(errorsmod.Wrap(err, "error creating ibc adapter"))
+		panic(errorsmod.Wrap(err, "error creating IBC adapter"))
 	}
 
 	in.Orbiters.SetAdapterControllers(ibc)

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -22,7 +22,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	cctptypes "github.com/circlefin/noble-cctp/x/cctp/types"
@@ -35,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -261,10 +261,10 @@ func preGenesis(ctx context.Context, suite *Suite) func(ibc.Chain) error {
 		var err error
 		fiatTfRoles.Pauser, err = nobleVal.BuildRelayerWallet(ctx, "pauser-ftf")
 		if err != nil {
-			return fmt.Errorf("failed to create wallet: %w", err)
+			return errorsmod.Wrap(err, "failed to create wallet")
 		}
 		if err := val.RecoverKey(ctx, fiatTfRoles.Pauser.KeyName(), fiatTfRoles.Pauser.Mnemonic()); err != nil {
-			return fmt.Errorf("failed to restore %s wallet: %w", fiatTfRoles.Pauser.KeyName(), err)
+			return errorsmod.Wrapf(err, "failed to restore %s wallet", fiatTfRoles.Pauser.KeyName())
 		}
 
 		genesisWallet := ibc.WalletAmount{
@@ -283,7 +283,7 @@ func preGenesis(ctx context.Context, suite *Suite) func(ibc.Chain) error {
 
 		fiatTfRoles.TokenMessenger, err = nobleVal.BuildRelayerWallet(ctx, "token-messenger-ftf")
 		if err != nil {
-			return fmt.Errorf("failed to create wallet: %w", err)
+			return errorsmod.Wrap(err, "failed to create wallet")
 		}
 
 		suite.CircleRoles = fiatTfRoles

--- a/keeper/component/adapter/adapter.go
+++ b/keeper/component/adapter/adapter.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 
 	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -151,11 +152,11 @@ func (a *Adapter) BeforeTransferHook(
 	}
 
 	if err := adapter.BeforeTransferHook(ctx, payload); err != nil {
-		return fmt.Errorf("before transfer hook failed: %w", err)
+		return errorsmod.Wrap(err, "before transfer hook failed")
 	}
 
 	if err := a.commonBeforeTransferHook(ctx, payload.Forwarding.PassthroughPayload); err != nil {
-		return fmt.Errorf("generic hook failed: %w", err)
+		return errorsmod.Wrap(err, "generic hook failed")
 	}
 
 	return nil
@@ -176,7 +177,7 @@ func (a *Adapter) AfterTransferHook(
 	}
 
 	if err := adapter.AfterTransferHook(ctx, payload); err != nil {
-		return nil, fmt.Errorf("after transfer hook failed: %w", err)
+		return nil, errorsmod.Wrap(err, "after transfer hook failed")
 	}
 
 	balances := a.bankKeeper.GetAllBalances(ctx, core.ModuleAddress)
@@ -191,7 +192,7 @@ func (a *Adapter) AfterTransferHook(
 		balances[0].Amount,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error creating transfer attributes: %w", err)
+		return nil, errorsmod.Wrap(err, "error creating transfer attributes")
 	}
 
 	return transferAttr, nil

--- a/keeper/component/adapter/genesis.go
+++ b/keeper/component/adapter/genesis.go
@@ -22,7 +22,6 @@ package adapter
 
 import (
 	"context"
-	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -34,9 +33,8 @@ func (a *Adapter) InitGenesis(ctx context.Context, g *adaptertypes.GenesisState)
 	if err := g.Validate(); err != nil {
 		return errorsmod.Wrap(err, "invalid adapter genesis state")
 	}
-
 	if err := a.SetParams(ctx, g.Params); err != nil {
-		return fmt.Errorf("error setting genesis params: %w", err)
+		return errorsmod.Wrap(err, "error setting genesis params")
 	}
 
 	return nil

--- a/keeper/component/dispatcher/dispatcher.go
+++ b/keeper/component/dispatcher/dispatcher.go
@@ -22,7 +22,6 @@ package dispatcher
 
 import (
 	"context"
-	"fmt"
 
 	"cosmossdk.io/collections"
 	errorsmod "cosmossdk.io/errors"
@@ -179,7 +178,7 @@ func (d *Dispatcher) dispatchActions(
 		)
 		err = d.dispatchActionPacket(ctx, packet)
 		if err != nil {
-			return fmt.Errorf("error dispatching action %s packet: %w", action.ID(), err)
+			return errorsmod.Wrapf(err, "error dispatching action %s packet", action.ID())
 		}
 	}
 	d.logger.Debug("completed actions dispatching")
@@ -197,10 +196,10 @@ func (d *Dispatcher) dispatchForwarding(
 	d.logger.Debug("started forwarding dispatching")
 	packet, err := types.NewForwardingPacket(transferAttr, forwarding)
 	if err != nil {
-		return fmt.Errorf(
-			"error creating forwarding packet for protocol ID %s: %w",
-			forwarding.ProtocolID(),
+		return errorsmod.Wrapf(
 			err,
+			"error creating forwarding packet for protocol ID %s",
+			forwarding.ProtocolID(),
 		)
 	}
 
@@ -215,10 +214,10 @@ func (d *Dispatcher) dispatchForwarding(
 	)
 	err = d.dispatchForwardingPacket(ctx, packet)
 	if err != nil {
-		return fmt.Errorf(
-			"error dispatching forwarding packet for protocol %s: %w",
-			packet.Forwarding.ProtocolID(),
+		return errorsmod.Wrapf(
 			err,
+			"error dispatching forwarding packet for protocol %s",
+			packet.Forwarding.ProtocolID(),
 		)
 	}
 

--- a/keeper/component/dispatcher/state.go
+++ b/keeper/component/dispatcher/state.go
@@ -299,7 +299,8 @@ func (d *Dispatcher) getDispatchedAmountEntryFromKey(
 // ====================================================================================================
 
 // DispatchedCountsKey is defined as:
-// (source protocol ID, source counterparty ID, destination protocol ID, destination counterparty ID).
+// (source protocol ID, source counterparty ID, destination protocol ID, destination counterparty
+// ID).
 type DispatchedCountsKey = collections.Quad[int32, string, int32, string]
 
 type DispatchedCountsIndexes struct {

--- a/keeper/component/executor/executor.go
+++ b/keeper/component/executor/executor.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 
 	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 
@@ -113,11 +114,7 @@ func (e *Executor) SetRouter(r ActionRouter) error {
 // Pause allows to pause an action controller.
 func (e *Executor) Pause(ctx context.Context, actionID core.ActionID) error {
 	if err := e.SetPausedAction(ctx, actionID); err != nil {
-		return fmt.Errorf(
-			"error pausing action %s: %w",
-			actionID,
-			err,
-		)
+		return errorsmod.Wrapf(err, "error pausing action %s", actionID)
 	}
 
 	return nil
@@ -126,11 +123,7 @@ func (e *Executor) Pause(ctx context.Context, actionID core.ActionID) error {
 // Unpause allows to unpause an action controller.
 func (e *Executor) Unpause(ctx context.Context, actionID core.ActionID) error {
 	if err := e.SetUnpausedAction(ctx, actionID); err != nil {
-		return fmt.Errorf(
-			"error unpausing action %s: %w",
-			actionID,
-			err,
-		)
+		return errorsmod.Wrapf(err, "error unpausing action %s", actionID)
 	}
 
 	return nil
@@ -155,12 +148,12 @@ func (e *Executor) HandlePacket(
 func (e *Executor) validatePacket(ctx context.Context, packet *types.ActionPacket) error {
 	err := packet.Validate()
 	if err != nil {
-		return fmt.Errorf("error validating action packet: %w", err)
+		return errorsmod.Wrap(err, "error validating action packet")
 	}
 
 	err = e.validateController(ctx, packet.Action.ID())
 	if err != nil {
-		return fmt.Errorf("error validating action controller: %w", err)
+		return errorsmod.Wrap(err, "error validating action controller")
 	}
 
 	return nil

--- a/keeper/component/executor/genesis.go
+++ b/keeper/component/executor/genesis.go
@@ -22,7 +22,8 @@ package executor
 
 import (
 	"context"
-	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 
 	executortypes "orbiter.dev/types/component/executor"
 )
@@ -36,7 +37,7 @@ func (e *Executor) InitGenesis(ctx context.Context, g *executortypes.GenesisStat
 	// NOTE: paused action ids are already validated
 	for _, id := range g.PausedActionIds {
 		if err := e.SetPausedAction(ctx, id); err != nil {
-			return fmt.Errorf("error setting genesis paused action ID: %w", err)
+			return errorsmod.Wrap(err, "error setting genesis paused action ID")
 		}
 	}
 

--- a/keeper/component/executor/query_server.go
+++ b/keeper/component/executor/query_server.go
@@ -22,7 +22,6 @@ package executor
 
 import (
 	"context"
-	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -54,7 +53,7 @@ func (s queryServer) IsActionPaused(
 
 	paused, err := s.Executor.IsActionPaused(ctx, req.ActionId)
 	if err != nil {
-		return nil, fmt.Errorf("unable to query action paused status: %w", err)
+		return nil, errorsmod.Wrapf(err, "unable to query action paused status")
 	}
 
 	return &executortypes.QueryIsActionPausedResponse{
@@ -73,7 +72,7 @@ func (s queryServer) PausedActions(
 
 	paused, err := s.GetPausedActions(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to query paused actions: %w", err)
+		return nil, errorsmod.Wrapf(err, "unable to query paused actions")
 	}
 
 	return &executortypes.QueryPausedActionsResponse{

--- a/keeper/component/executor/state.go
+++ b/keeper/component/executor/state.go
@@ -22,7 +22,8 @@ package executor
 
 import (
 	"context"
-	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 
 	"orbiter.dev/types/core"
 )
@@ -85,7 +86,7 @@ func (e *Executor) GetPausedActions(
 
 		id, err := core.NewActionID(k)
 		if err != nil {
-			return nil, fmt.Errorf("cannot create action ID from iterator key: %w", err)
+			return nil, errorsmod.Wrap(err, "cannot create action ID from iterator key")
 		}
 		paused = append(paused, id)
 	}

--- a/keeper/component/forwarder/genesis.go
+++ b/keeper/component/forwarder/genesis.go
@@ -42,7 +42,7 @@ func (f *Forwarder) InitGenesis(ctx context.Context, g *forwardertypes.GenesisSt
 
 	for _, id := range g.PausedCrossChainIds {
 		if err := f.SetPausedCrossChain(ctx, *id); err != nil {
-			return errorsmod.Wrap(err, "error setting genesis paused cross-chain id")
+			return errorsmod.Wrap(err, "error setting genesis paused cross-chain ID")
 		}
 	}
 

--- a/keeper/component/forwarder/genesis.go
+++ b/keeper/component/forwarder/genesis.go
@@ -22,7 +22,8 @@ package forwarder
 
 import (
 	"context"
-	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 
 	forwardertypes "orbiter.dev/types/component/forwarder"
 )
@@ -35,13 +36,13 @@ func (f *Forwarder) InitGenesis(ctx context.Context, g *forwardertypes.GenesisSt
 
 	for _, id := range g.PausedProtocolIds {
 		if err := f.SetPausedProtocol(ctx, id); err != nil {
-			return fmt.Errorf("error setting genesis paused protocol ID: %w", err)
+			return errorsmod.Wrap(err, "error setting genesis paused protocol ID")
 		}
 	}
 
 	for _, id := range g.PausedCrossChainIds {
 		if err := f.SetPausedCrossChain(ctx, *id); err != nil {
-			return fmt.Errorf("error setting genesis paused cross-chain id: %w", err)
+			return errorsmod.Wrap(err, "error setting genesis paused cross-chain id")
 		}
 	}
 

--- a/keeper/component/forwarder/msg_server.go
+++ b/keeper/component/forwarder/msg_server.go
@@ -130,7 +130,7 @@ func (s msgServer) ReplaceDepositForBurn(
 
 	controller, found := s.router.Route(core.PROTOCOL_CCTP)
 	if !found {
-		return nil, errors.New("cctp controller not found")
+		return nil, errors.New("CCTP controller not found")
 	}
 
 	cctpController, ok := controller.(*forwarding.CCTPController)

--- a/keeper/component/forwarder/query_server.go
+++ b/keeper/component/forwarder/query_server.go
@@ -22,8 +22,8 @@ package forwarder
 
 import (
 	"context"
-	"fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	forwardertypes "orbiter.dev/types/component/forwarder"
@@ -49,12 +49,12 @@ func (s queryServer) IsProtocolPaused(
 		return nil, sdkerrors.ErrInvalidRequest
 	}
 	if err := req.ProtocolId.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid protocol ID: %w", err)
+		return nil, errorsmod.Wrap(err, "invalid protocol ID")
 	}
 
 	paused, err := s.Forwarder.IsProtocolPaused(ctx, req.ProtocolId)
 	if err != nil {
-		return nil, fmt.Errorf("unable to query protocol paused status: %w", err)
+		return nil, errorsmod.Wrap(err, "unable to query protocol paused status")
 	}
 
 	return &forwardertypes.QueryIsProtocolPausedResponse{
@@ -73,7 +73,7 @@ func (s queryServer) PausedProtocols(
 
 	paused, err := s.GetPausedProtocols(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to query paused protocols: %w", err)
+		return nil, errorsmod.Wrap(err, "unable to query paused protocols")
 	}
 
 	return &forwardertypes.QueryPausedProtocolsResponse{
@@ -91,12 +91,12 @@ func (s queryServer) IsCrossChainPaused(
 
 	ccID, err := core.NewCrossChainID(req.ProtocolId, req.CounterpartyId)
 	if err != nil {
-		return nil, fmt.Errorf("unable to query cross-chain paused status: %w", err)
+		return nil, errorsmod.Wrap(err, "unable to query cross-chain paused status")
 	}
 
 	paused, err := s.Forwarder.IsCrossChainPaused(ctx, ccID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to query cross-chain paused status: %w", err)
+		return nil, errorsmod.Wrap(err, "unable to query cross-chain paused status")
 	}
 
 	return &forwardertypes.QueryIsCrossChainPausedResponse{
@@ -115,11 +115,11 @@ func (s queryServer) PausedCrossChains(
 
 	id := req.ProtocolId
 	if err := id.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid protocol ID: %w", err)
+		return nil, errorsmod.Wrap(err, "invalid protocol ID")
 	}
 	paused, err := s.GetPausedCrossChainsMap(ctx, &id)
 	if err != nil {
-		return nil, fmt.Errorf("unable to query paused counterparty: %w", err)
+		return nil, errorsmod.Wrap(err, "unable to query paused counterparty")
 	}
 
 	return &forwardertypes.QueryPausedCrossChainsResponse{

--- a/keeper/component/forwarder/query_server.go
+++ b/keeper/component/forwarder/query_server.go
@@ -119,7 +119,7 @@ func (s queryServer) PausedCrossChains(
 	}
 	paused, err := s.GetPausedCrossChainsMap(ctx, &id)
 	if err != nil {
-		return nil, errorsmod.Wrap(err, "unable to query paused counterparty")
+		return nil, errorsmod.Wrap(err, "unable to query paused cross-chains")
 	}
 
 	return &forwardertypes.QueryPausedCrossChainsResponse{

--- a/keeper/component/forwarder/state.go
+++ b/keeper/component/forwarder/state.go
@@ -22,9 +22,9 @@ package forwarder
 
 import (
 	"context"
-	"fmt"
 
 	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 
 	"orbiter.dev/types/core"
 )
@@ -209,7 +209,7 @@ func (f *Forwarder) GetPausedCrossChainsMap(
 	for ; iter.Valid(); iter.Next() {
 		key, err := iter.Key()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get key from iterator: %w", err)
+			return nil, errorsmod.Wrap(err, "failed to get key from iterator")
 		}
 
 		pID := key.K1()

--- a/keeper/genesis.go
+++ b/keeper/genesis.go
@@ -22,7 +22,8 @@ package keeper
 
 import (
 	"context"
-	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 
 	"orbiter.dev/types"
 )
@@ -31,19 +32,19 @@ import (
 // a genesis state.
 func (k *Keeper) InitGenesis(ctx context.Context, g types.GenesisState) {
 	if err := k.adapter.InitGenesis(ctx, g.AdapterGenesis); err != nil {
-		panic(fmt.Errorf("unable to initialize adapter genesis state %w", err))
+		panic(errorsmod.Wrap(err, "unable to initialize adapter genesis state"))
 	}
 
 	if err := k.dispatcher.InitGenesis(ctx, g.DispatcherGenesis); err != nil {
-		panic(fmt.Errorf("unable to initialize dispatcher genesis state %w", err))
+		panic(errorsmod.Wrap(err, "unable to initialize dispatcher genesis state"))
 	}
 
 	if err := k.forwarder.InitGenesis(ctx, g.ForwarderGenesis); err != nil {
-		panic(fmt.Errorf("unable to initialize forwarder genesis state %w", err))
+		panic(errorsmod.Wrap(err, "unable to initialize forwarder genesis state"))
 	}
 
 	if err := k.executor.InitGenesis(ctx, g.ExecutorGenesis); err != nil {
-		panic(fmt.Errorf("unable to initialize executor genesis state %w", err))
+		panic(errorsmod.Wrap(err, "unable to initialize executor genesis state"))
 	}
 }
 

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -27,6 +27,7 @@ import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/store"
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 
@@ -216,22 +217,22 @@ func (k *Keeper) setComponents(
 ) error {
 	executor, err := executorcomp.New(cdc, sb, logger)
 	if err != nil {
-		return fmt.Errorf("error creating a new action component: %w", err)
+		return errorsmod.Wrap(err, "error creating a new action component")
 	}
 
 	forwarder, err := forwardercomp.New(cdc, sb, logger, bankKeeper)
 	if err != nil {
-		return fmt.Errorf("error creating a new forwarding component: %w", err)
+		return errorsmod.Wrap(err, "error creating a new forwarding component")
 	}
 
 	dispatcher, err := dispatchercomp.New(cdc, sb, logger, forwarder, executor)
 	if err != nil {
-		return fmt.Errorf("error creating a new dispatcher component: %w", err)
+		return errorsmod.Wrap(err, "error creating a new dispatcher component")
 	}
 
 	adapter, err := adaptercomp.New(cdc, sb, logger, bankKeeper, dispatcher)
 	if err != nil {
-		return fmt.Errorf("error creating a new adapter component: %w", err)
+		return errorsmod.Wrap(err, "error creating a new adapter component")
 	}
 
 	k.executor = executor

--- a/module.go
+++ b/module.go
@@ -22,11 +22,11 @@ package orbiter
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"cosmossdk.io/core/appmodule"
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -107,7 +107,7 @@ func (AppModuleBasic) ValidateGenesis(
 ) error {
 	var genesis types.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &genesis); err != nil {
-		return fmt.Errorf("failed to unmarshal x/%s genesis state: %w", core.ModuleName, err)
+		return errorsmod.Wrapf(err, "failed to unmarshal x/%s genesis state", core.ModuleName)
 	}
 
 	return genesis.Validate()

--- a/simapp/export.go
+++ b/simapp/export.go
@@ -2,8 +2,8 @@ package simapp
 
 import (
 	"encoding/json"
-	"fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
@@ -27,7 +27,7 @@ func (app *SimApp) ExportAppStateAndValidators(
 
 	genState, err := app.ModuleManager.ExportGenesis(ctx, app.appCodec)
 	if err != nil {
-		return servertypes.ExportedApp{}, fmt.Errorf("failed to export genesis state: %w", err)
+		return servertypes.ExportedApp{}, errorsmod.Wrap(err, "failed to export genesis state")
 	}
 
 	appState, err := json.MarshalIndent(genState, "", "  ")

--- a/types/component/forwarder/genesis.go
+++ b/types/component/forwarder/genesis.go
@@ -52,7 +52,7 @@ func (g *GenesisState) Validate() error {
 		}
 
 		if err := id.Validate(); err != nil {
-			return errorsmod.Wrapf(err, "invalid paused cross-chain ID %q", id)
+			return errorsmod.Wrapf(err, "invalid paused cross-chain ID %v", id)
 		}
 	}
 

--- a/types/component/forwarder/genesis.go
+++ b/types/component/forwarder/genesis.go
@@ -21,8 +21,6 @@
 package forwarder
 
 import (
-	"fmt"
-
 	errorsmod "cosmossdk.io/errors"
 
 	core "orbiter.dev/types/core"
@@ -54,7 +52,7 @@ func (g *GenesisState) Validate() error {
 		}
 
 		if err := id.Validate(); err != nil {
-			return fmt.Errorf("invalid paused cross-chain ID %q: %w", id, err)
+			return errorsmod.Wrapf(err, "invalid paused cross-chain ID %q", id)
 		}
 	}
 

--- a/types/component/forwarder/genesis_test.go
+++ b/types/component/forwarder/genesis_test.go
@@ -39,7 +39,7 @@ func TestValidate(t *testing.T) {
 			genState: DefaultGenesisState(),
 		},
 		{
-			name: "success - valid genesis state with protocol and cross-chain ids",
+			name: "success - valid genesis state with protocol and cross-chain IDs",
 			genState: &GenesisState{
 				PausedProtocolIds: []core.ProtocolID{core.PROTOCOL_IBC, core.PROTOCOL_CCTP},
 				PausedCrossChainIds: []*core.CrossChainID{
@@ -61,7 +61,7 @@ func TestValidate(t *testing.T) {
 			expErr: "invalid paused protocol ID",
 		},
 		{
-			name: "error - invalid genesis state (nil cross-chain id)",
+			name: "error - invalid genesis state (nil cross-chain ID)",
 			genState: &GenesisState{
 				PausedCrossChainIds: []*core.CrossChainID{nil},
 			},

--- a/types/controller/forwarding/cctp.go
+++ b/types/controller/forwarding/cctp.go
@@ -52,7 +52,7 @@ func NewCCTPAttributes(
 // Validate returns an error if the CCTP attributes are not valid.
 func (a *CCTPAttributes) Validate() error {
 	if a == nil {
-		return core.ErrNilPointer.Wrap("cctp attributes")
+		return core.ErrNilPointer.Wrap("CCTP attributes")
 	}
 
 	if a.DestinationDomain == core.CCTPNobleDomain {

--- a/types/core/id.go
+++ b/types/core/id.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	errorsmod "cosmossdk.io/errors"
 )
 
 type IdentifierConstraint interface {
@@ -97,7 +99,7 @@ func NewCrossChainID(
 
 	err := id.Validate()
 	if err != nil {
-		return CrossChainID{}, fmt.Errorf("invalid cross-chain ID: %w", err)
+		return CrossChainID{}, errorsmod.Wrap(err, "invalid cross-chain ID")
 	}
 
 	return id, nil
@@ -152,13 +154,13 @@ func ParseCrossChainID(str string) (CrossChainID, error) {
 
 	id, err := strconv.ParseInt(protocolIDStr, 10, 32)
 	if err != nil {
-		return CrossChainID{}, fmt.Errorf("invalid protocol ID: %w", err)
+		return CrossChainID{}, errorsmod.Wrap(err, "invalid protocol ID")
 	}
 
 	protocolID := ProtocolID(int32(id))
 	ccID, err := NewCrossChainID(protocolID, counterpartyID)
 	if err != nil {
-		return CrossChainID{}, fmt.Errorf("invalid cross-chain ID string %s: %w", str, err)
+		return CrossChainID{}, errorsmod.Wrapf(err, "invalid cross-chain ID string %s", str)
 	}
 
 	return ccID, nil

--- a/types/core/orbiter.go
+++ b/types/core/orbiter.go
@@ -21,8 +21,7 @@
 package core
 
 import (
-	"errors"
-
+	errorsmod "cosmossdk.io/errors"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/gogoproto/proto"
@@ -52,14 +51,14 @@ func NewAction(id ActionID, attr ActionAttributes) (*Action, error) {
 // Validate returns an error if the action is not valid.
 func (a *Action) Validate() error {
 	if a == nil {
-		return errors.New("nil pointer: action is not set")
+		return errorsmod.Wrap(ErrNilPointer, "action is not set")
 	}
 	if err := a.Id.Validate(); err != nil {
 		return err
 	}
 
 	if a.Attributes == nil {
-		return errors.New("nil pointer: action attributes are not set")
+		return errorsmod.Wrap(ErrNilPointer, "action attributes are not set")
 	}
 
 	return nil
@@ -80,11 +79,11 @@ func (a *Action) ID() ActionID {
 // attributes set.
 func (a *Action) CachedAttributes() (ActionAttributes, error) {
 	if a == nil {
-		return nil, errors.New("nil pointer: action is not set")
+		return nil, errorsmod.Wrap(ErrNilPointer, "action is not set")
 	}
 
 	if a.Attributes == nil {
-		return nil, errors.New("nil pointer: action attributes are not set")
+		return nil, errorsmod.Wrap(ErrNilPointer, "action attributes are not set")
 	}
 	av := a.Attributes.GetCachedValue()
 	attr, ok := av.(ActionAttributes)
@@ -102,7 +101,7 @@ func (a *Action) CachedAttributes() (ActionAttributes, error) {
 // SetAttributes sets the action attributes into the action as codec Any type.
 func (a *Action) SetAttributes(attr ActionAttributes) error {
 	if a == nil {
-		return errors.New("nil pointer: action is not set")
+		return errorsmod.Wrap(ErrNilPointer, "action is not set")
 	}
 
 	m, ok := attr.(proto.Message)
@@ -123,7 +122,7 @@ func (a *Action) SetAttributes(attr ActionAttributes) error {
 // an Any type into an interface registered in the codec.
 func (a *Action) UnpackInterfaces(unpacker cdctypes.AnyUnpacker) error {
 	if a == nil {
-		return errors.New("nil pointer: action is not set")
+		return errorsmod.Wrap(ErrNilPointer, "action is not set")
 	}
 	var attributes ActionAttributes
 
@@ -161,13 +160,13 @@ func NewForwarding(
 // Validate returns an error if the forwarding is not valid.
 func (f *Forwarding) Validate() error {
 	if f == nil {
-		return errors.New("nil pointer: forwarding is not set")
+		return errorsmod.Wrap(ErrNilPointer, "forwarding is not set")
 	}
 	if err := f.ProtocolId.Validate(); err != nil {
 		return err
 	}
 	if f.Attributes == nil {
-		return errors.New("nil pointer: forwarding attributes are not set")
+		return errorsmod.Wrap(ErrNilPointer, "forwarding attributes are not set")
 	}
 
 	return nil
@@ -188,10 +187,10 @@ func (f *Forwarding) ProtocolID() ProtocolID {
 // attributes set.
 func (f *Forwarding) CachedAttributes() (ForwardingAttributes, error) {
 	if f == nil {
-		return nil, errors.New("nil pointer: forwarding is not set")
+		return nil, errorsmod.Wrap(ErrNilPointer, "forwarding is not set")
 	}
 	if f.Attributes == nil {
-		return nil, errors.New("nil pointer: forwarding attributes are not set")
+		return nil, errorsmod.Wrap(ErrNilPointer, "forwarding attributes are not set")
 	}
 	av := f.Attributes.GetCachedValue()
 	a, ok := av.(ForwardingAttributes)
@@ -209,7 +208,7 @@ func (f *Forwarding) CachedAttributes() (ForwardingAttributes, error) {
 // SetAttributes sets the attributes as codec Any type.
 func (f *Forwarding) SetAttributes(a ForwardingAttributes) error {
 	if f == nil {
-		return errors.New("nil pointer: forwarding is not set")
+		return errorsmod.Wrap(ErrNilPointer, "forwarding is not set")
 	}
 	// The interface we want to pack as any must
 	// implement the proto Message interface.
@@ -233,7 +232,7 @@ func (f *Forwarding) SetAttributes(a ForwardingAttributes) error {
 // an Any type into an interface registered in the codec.
 func (f *Forwarding) UnpackInterfaces(unpacker cdctypes.AnyUnpacker) error {
 	if f == nil {
-		return errors.New("nil pointer: forwarding is not set")
+		return errorsmod.Wrap(ErrNilPointer, "forwarding is not set")
 	}
 
 	var attributes ForwardingAttributes
@@ -267,7 +266,7 @@ func NewPayload(
 // not valid.
 func (p *Payload) Validate() error {
 	if p == nil {
-		return errors.New("nil pointer: payload is not set")
+		return errorsmod.Wrap(ErrNilPointer, "payload is not set")
 	}
 
 	for _, action := range p.PreActions {
@@ -283,7 +282,7 @@ var _ cdctypes.UnpackInterfacesMessage = &Payload{}
 
 func (p *Payload) UnpackInterfaces(unpacker cdctypes.AnyUnpacker) error {
 	if p == nil {
-		return errors.New("nil pointer: payload is not set")
+		return errorsmod.Wrap(ErrNilPointer, "payload is not set")
 	}
 
 	if p.PreActions != nil {
@@ -326,7 +325,7 @@ func NewPayloadWrapper(
 // contains non valid fields.
 func (pw *PayloadWrapper) Validate() error {
 	if pw == nil {
-		return errors.New("nil pointer: payload wrapper is not set")
+		return errorsmod.Wrap(ErrNilPointer, "payload wrapper is not set")
 	}
 
 	return pw.Orbiter.Validate()

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -21,7 +21,7 @@
 package types
 
 import (
-	"fmt"
+	errorsmod "cosmossdk.io/errors"
 
 	"orbiter.dev/types/component/adapter"
 	"orbiter.dev/types/component/dispatcher"
@@ -43,19 +43,19 @@ func DefaultGenesisState() *GenesisState {
 // Validate returns an error if any of the genesis fields is not valid.
 func (g *GenesisState) Validate() error {
 	if err := g.AdapterGenesis.Validate(); err != nil {
-		return fmt.Errorf("error validating adapter component genesis state: %w", err)
+		return errorsmod.Wrap(err, "error validating adapter component genesis state")
 	}
 
 	if err := g.DispatcherGenesis.Validate(); err != nil {
-		return fmt.Errorf("error validating dispatcher component genesis state: %w", err)
+		return errorsmod.Wrap(err, "error validating dispatcher component genesis state")
 	}
 
 	if err := g.ForwarderGenesis.Validate(); err != nil {
-		return fmt.Errorf("error validating forwarder component genesis state: %w", err)
+		return errorsmod.Wrap(err, "error validating forwarder component genesis state")
 	}
 
 	if err := g.ExecutorGenesis.Validate(); err != nil {
-		return fmt.Errorf("error validating executor component genesis state: %w", err)
+		return errorsmod.Wrap(err, "error validating executor component genesis state")
 	}
 
 	return nil

--- a/types/packet.go
+++ b/types/packet.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	fmt "fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -76,13 +77,13 @@ func (a *TransferAttributes) Validate() error {
 		return err
 	}
 	if err := a.sourceCoin.Validate(); err != nil {
-		return fmt.Errorf("source coin validation error: %w", err)
+		return errorsmod.Wrap(err, "source coin validation error")
 	}
 	if !a.sourceCoin.IsPositive() {
 		return errors.New("source amount must be positive")
 	}
 	if err := a.destinationCoin.Validate(); err != nil {
-		return fmt.Errorf("destination coin validation error: %w", err)
+		return errorsmod.Wrap(err, "destination coin validation error")
 	}
 	if !a.destinationCoin.IsPositive() {
 		return errors.New("destination amount must be positive")

--- a/types/router/router.go
+++ b/types/router/router.go
@@ -69,7 +69,7 @@ func (r *Router[ID, T]) AddRoute(route T) error {
 	}
 	routeID := route.ID()
 	if err := routeID.Validate(); err != nil {
-		return errors.New("route id is not valid")
+		return errors.New("route ID is not valid")
 	}
 
 	if r.HasRoute(routeID) {


### PR DESCRIPTION
This PR replaces the usage of `fmt.Errorf("... %w", err)` by using the `errorsmod.Wrap` and `errorsmod.Wrapf` methods respectively to enforce a standard approach to wrapping errors in the repo.

You can check this by running `grep -r -e 'fmt.Errorf.*%w'`, which should show no more occurrences of this pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - More consistent, contextual error messages across initialization, queries, validation, and pause/unpause operations.
- Refactor
  - Standardized error handling to cosmossdk.io/errors across components for clearer diagnostics without changing behavior or APIs.
- Documentation
  - Minor comment formatting improvements.
- Chores
  - Unified error reporting during genesis validation/export and controller/adapter setup for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->