### PR TITLE
refactor: unify adapter interfaces and remove unused ones

### DIFF
--- a/controller/adapter/ibc.go
+++ b/controller/adapter/ibc.go
@@ -21,8 +21,6 @@
 package adapter
 
 import (
-	"context"
-
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -70,20 +68,11 @@ func NewIBCAdapter(cdc codec.Codec, logger log.Logger) (*IBCAdapter, error) {
 }
 
 // ParsePayload dispatches the payload parsing to the underlying IBC parser.
-func (a *IBCAdapter) ParsePayload(payloadBz []byte) (bool, *core.Payload, error) {
-	return a.parser.ParsePayload(payloadBz)
-}
-
-// BeforeTransferHook run logic before executing the IBC transfer to the
-// orbiter module.
-func (a *IBCAdapter) BeforeTransferHook(context.Context, *core.Payload) error {
-	return nil
-}
-
-// AfterTransferHook run logic after executing the IBC transfer to the orbiter
-// module.
-func (a *IBCAdapter) AfterTransferHook(context.Context, *core.Payload) error {
-	return nil
+func (a *IBCAdapter) ParsePayload(
+	id core.ProtocolID,
+	payloadBz []byte,
+) (bool, *core.Payload, error) {
+	return a.parser.ParsePayload(id, payloadBz)
 }
 
 var _ types.PayloadParser = &IBCParser{}
@@ -113,7 +102,7 @@ func NewIBCParser(cdc codec.Codec) (*IBCParser, error) {
 // - bool: whether the payload is intended for the Orbiter module.
 // - Payload: the parsed payload.
 // - error: an error, if one occurred during parsing.
-func (p *IBCParser) ParsePayload(payloadBz []byte) (bool, *core.Payload, error) {
+func (p *IBCParser) ParsePayload(_ core.ProtocolID, payloadBz []byte) (bool, *core.Payload, error) {
 	data, err := p.GetICS20PacketData(payloadBz)
 	if err != nil {
 		// Despite the error is not nil, we don't return it. We

--- a/controller/adapter/ibc_test.go
+++ b/controller/adapter/ibc_test.go
@@ -21,7 +21,6 @@
 package adapter_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,22 +29,9 @@ import (
 
 	adapterctrl "orbiter.dev/controller/adapter"
 	"orbiter.dev/testutil"
-	"orbiter.dev/testutil/mocks"
 	"orbiter.dev/testutil/testdata"
 	"orbiter.dev/types/core"
 )
-
-func TestHooks(t *testing.T) {
-	deps := mocks.NewDependencies(t)
-	adapter, err := adapterctrl.NewIBCAdapter(deps.EncCfg.Codec, deps.Logger)
-	require.NoError(t, err)
-
-	err = adapter.AfterTransferHook(context.Background(), &core.Payload{})
-	require.NoError(t, err)
-
-	err = adapter.BeforeTransferHook(context.Background(), &core.Payload{})
-	require.NoError(t, err)
-}
 
 func TestNewIBCParser(t *testing.T) {
 	parser, err := adapterctrl.NewIBCParser(nil)
@@ -175,7 +161,7 @@ func TestParsePayload(t *testing.T) {
 			parser, err := adapterctrl.NewIBCParser(encCfg.Codec)
 			require.NoError(t, err)
 
-			isOrbiterPayload, payload, err := parser.ParsePayload(tc.payloadBz)
+			isOrbiterPayload, payload, err := parser.ParsePayload(core.PROTOCOL_IBC, tc.payloadBz)
 
 			require.Equal(t, tc.expectIsOrbiter, isOrbiterPayload)
 			if tc.expectError {

--- a/testutil/mocks/controllers.go
+++ b/testutil/mocks/controllers.go
@@ -92,26 +92,11 @@ func (a *NoOpAdapterController) Name() string {
 	return a.Id.String()
 }
 
-// AfterTransferHook implements types.AdapterProtocol.
-func (a *NoOpAdapterController) AfterTransferHook(ctx context.Context, _ *core.Payload) error {
-	if CheckIfFailing(ctx) {
-		return errors.New("error in after transfer hook")
-	}
-
-	return nil
-}
-
-// BeforeTransferHook implements types.AdapterProtocol.
-func (a *NoOpAdapterController) BeforeTransferHook(ctx context.Context, _ *core.Payload) error {
-	if CheckIfFailing(ctx) {
-		return errors.New("error in before transfer hook")
-	}
-
-	return nil
-}
-
 // ParsePayload implements types.AdapterProtocol.
-func (a *NoOpAdapterController) ParsePayload(bz []byte) (bool, *core.Payload, error) {
+func (a *NoOpAdapterController) ParsePayload(
+	id core.ProtocolID,
+	bz []byte,
+) (bool, *core.Payload, error) {
 	if string(bz) == "failing" {
 		return false, nil, errors.New("error parsing payload")
 	}

--- a/testutil/mocks/controllers.go
+++ b/testutil/mocks/controllers.go
@@ -94,7 +94,7 @@ func (a *NoOpAdapterController) Name() string {
 
 // ParsePayload implements types.AdapterProtocol.
 func (a *NoOpAdapterController) ParsePayload(
-	id core.ProtocolID,
+	_ core.ProtocolID,
 	bz []byte,
 ) (bool, *core.Payload, error) {
 	if string(bz) == "failing" {

--- a/types/adapter.go
+++ b/types/adapter.go
@@ -42,9 +42,7 @@ type TransferHookHandler interface {
 // PayloadAdapter defines the behavior expected by the adapter to handle
 // a generic orbiter payload.
 type PayloadAdapter interface {
-	// ParsePayload allows to parse and validate if the
-	// input bytes represent an orbiter payload.
-	ParsePayload(core.ProtocolID, []byte) (bool, *core.Payload, error)
+	PayloadParser
 	TransferHookHandler
 	// ProcessPayload processes the parsed payload.
 	ProcessPayload(context.Context, *TransferAttributes, *core.Payload) error

--- a/types/controller.go
+++ b/types/controller.go
@@ -21,8 +21,6 @@
 package types
 
 import (
-	"context"
-
 	"orbiter.dev/types/core"
 	"orbiter.dev/types/router"
 )
@@ -46,12 +44,6 @@ type ControllerAction interface {
 type ControllerAdapter interface {
 	Controller[core.ProtocolID]
 	PayloadParser
-	// BeforeTransferHook allows to execute logic BEFORE completing
-	// the cross-chain transfer.
-	BeforeTransferHook(context.Context, *core.Payload) error
-	// AfterTransferHook allows to execute logic AFTER completing
-	// the cross-chain transfer.
-	AfterTransferHook(context.Context, *core.Payload) error
 }
 
 // Controller defines the behavior common to

--- a/types/parser.go
+++ b/types/parser.go
@@ -31,5 +31,5 @@ type PayloadParser interface {
 	// orbiter payload. It returns a boolean to inform if
 	// the bytes represent an orbiter payload or not. The
 	// parsing is executed only if the boolean is true.
-	ParsePayload([]byte) (bool, *core.Payload, error)
+	ParsePayload(core.ProtocolID, []byte) (bool, *core.Payload, error)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated payload parsing to accept a protocol identifier across adapters and routing.
  * Removed per-protocol transfer hooks; transfers now use a common pre-transfer flow.
  * No functional change to IBC payload parsing; existing transfers continue to work as before.

* **Tests**
  * Updated tests and mocks for the new parsing signature and removed hook-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->