### PR TITLE
fix: update integration docs with correct payload example

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -53,8 +53,8 @@ An example of a JSON structured payload is:
         "@type": "/noble.orbiter.controller.forwarding.v1.CCTPAttributes",
         "destination_domain": 0,
         // Note: mint_recipient and destination_caller are 32-byte values encoded as base64
-        "mint_recipient": "7b6itDboIvromBxhpKmxmV5jBhRgTDa+uBzdEYB4FDA=",
-        "destination_caller": "EtJiMWGCpEspKte/kSZmSmRRu7XrUCEnlMn+G8+2b0U="
+        "mint_recipient": "PNWAxASH2RPmgMV+/Tb4e78ON1WL8SoFGnwbWWHxfuA=",
+        "destination_caller": "xWtN0TuqjWo90XiknI61JUxYexN2JgZaEaWGxhA/rXE="
       },
       "passthrough_payload": ""
     }


### PR DESCRIPTION
The payload example in `integration.md` was out-of-date with the current implementation (e.g. using `orbits` instead of `forwarding`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated integration guide to reflect top-level field rename from “orbit” to “forwarding.”
  * Aligned attribute namespaces/paths with the latest API naming.
  * Refreshed payload example data with new base64-encoded sample values and repositioned note on 32-byte fields.
  * Ensured examples match the current API structure for forwarding/CCTP attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->