### PR TITLE
chore: support pushing protobuf to registry

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -2,6 +2,7 @@
 version: v2
 modules:
   - path: proto
+    name: buf.build/noble-assets/orbiter
 deps:
   - buf.build/cosmos/cosmos-proto:1935555c206d4afb9e94615dfd0fad31
   - buf.build/cosmos/cosmos-sdk:v0.50.0
@@ -11,7 +12,6 @@ lint:
   enum_zero_value_suffix: UNSUPPORTED
   use:
     - STANDARD
-    # - COMMENTS
     - FILE_LOWER_SNAKE_CASE
   except:
     - SERVICE_SUFFIX


### PR DESCRIPTION
This PR adds the missing field to support pushing Protobuf to the Buf Schema Registry (BSR)!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Assigned a canonical name to the protobuf module.
  * Expanded protobuf dependencies to include gogo-proto and Google APIs for broader type coverage.
  * Cleaned up lint configuration by removing an unused commented rule.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->