### PR TITLE
imp: check for nil forwarding packet in CCTP controller

### DIFF
--- a/controller/forwarding/cctp.go
+++ b/controller/forwarding/cctp.go
@@ -94,6 +94,10 @@ func (c *CCTPController) Validate() error {
 
 // HandlePacket validates and process a CCTP cross-chain transfer.
 func (c *CCTPController) HandlePacket(ctx context.Context, packet *types.ForwardingPacket) error {
+	if packet == nil {
+		return errorsmod.Wrap(core.ErrNilPointer, "CCTP controller received nil packet")
+	}
+
 	attr, err := c.ExtractAttributes(packet.Forwarding)
 	if err != nil {
 		return core.ErrInvalidAttributes.Wrap(err.Error())

--- a/controller/forwarding/cctp_test.go
+++ b/controller/forwarding/cctp_test.go
@@ -129,6 +129,11 @@ func TestHandlePacket(t *testing.T) {
 			},
 		},
 		{
+			name:     "error - when the forwarding packet is nil",
+			packet:   func() *types.ForwardingPacket { return nil },
+			expError: "CCTP controller received nil packet",
+		},
+		{
 			name: "error - CCTP server returns an error",
 			setup: func() context.Context {
 				return context.WithValue(context.Background(), mocks.FailingContextKey, true)


### PR DESCRIPTION
Given that the `HandlePacket` method is the only method exposed by the controller interface, it is better to check for a nil received packet there. This packet is passed by the dispatcher, which loves the forwarder, and would never pass to it a nil pointer, but who knows.