### PR TITLE
refactor: handle dust collector as a module account

### DIFF
--- a/e2e/ibc_to_cctp_test.go
+++ b/e2e/ibc_to_cctp_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/math"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 
@@ -341,9 +342,11 @@ func testIbcPassingWithoutActions(
 		}
 	}
 
+	dcAddr := authtypes.NewModuleAddress(core.DustCollectorName)
+
 	resp, err := s.Chain.GetBalance(
 		ctx,
-		core.DustCollectorAddress.String(),
+		dcAddr.String(),
 		Usdc,
 	)
 	require.NoError(t, err)

--- a/keeper/component/adapter/adapter.go
+++ b/keeper/component/adapter/adapter.go
@@ -235,8 +235,8 @@ func (a *Adapter) clearOrbiterBalances(ctx context.Context) error {
 
 	return a.bankKeeper.SendCoinsFromModuleToModule(
 		ctx,
-		core.ModuleAddress.String(),
-		core.DustCollectorAddress.String(),
+		core.ModuleName,
+		core.DustCollectorName,
 		coins,
 	)
 }

--- a/keeper/component/adapter/adapter.go
+++ b/keeper/component/adapter/adapter.go
@@ -233,7 +233,12 @@ func (a *Adapter) clearOrbiterBalances(ctx context.Context) error {
 		return nil
 	}
 
-	return a.bankKeeper.SendCoins(ctx, core.ModuleAddress, core.DustCollectorAddress, coins)
+	return a.bankKeeper.SendCoinsFromModuleToModule(
+		ctx,
+		core.ModuleAddress.String(),
+		core.DustCollectorAddress.String(),
+		coins,
+	)
 }
 
 func (a *Adapter) validateModuleBalance(coins sdk.Coins) error {

--- a/simapp/app.yaml
+++ b/simapp/app.yaml
@@ -42,11 +42,17 @@ modules:
           permissions: [burner, minter]
         - account: cctp
         - account: orbiter
+        - account: orbiter/dust_collector
   - name: bank
     config:
       '@type': cosmos.bank.module.v1.Module
       blocked_module_accounts_override:
-        [auth, bonded_tokens_pool, not_bonded_tokens_pool]
+        [
+          auth,
+          bonded_tokens_pool,
+          not_bonded_tokens_pool,
+          orbiter/dust_collector,
+        ]
   - name: consensus
     config:
       '@type': cosmos.consensus.module.v1.Module

--- a/testutil/mocks/controllers.go
+++ b/testutil/mocks/controllers.go
@@ -31,17 +31,17 @@ import (
 var _ types.ControllerForwarding = &ForwardingController{}
 
 type ForwardingController struct {
-	Id core.ProtocolID
+	protocolID core.ProtocolID
 }
 
 // ID implements core.ForwardingController.
 func (o *ForwardingController) ID() core.ProtocolID {
-	return o.Id
+	return o.protocolID
 }
 
 // Name implements core.ForwardingController.
 func (o *ForwardingController) Name() string {
-	return o.Id.String()
+	return o.protocolID.String()
 }
 
 // HandlePacket implements core.ForwardingController.
@@ -56,17 +56,17 @@ func (o *ForwardingController) HandlePacket(ctx context.Context, _ *types.Forwar
 var _ types.ControllerAction = &NoOpActionController{}
 
 type NoOpActionController struct {
-	Id core.ActionID
+	actionID core.ActionID
 }
 
 // ID implements core.ActionController.
 func (a *NoOpActionController) ID() core.ActionID {
-	return a.Id
+	return a.actionID
 }
 
 // Name implements core.ActionController.
 func (a *NoOpActionController) Name() string {
-	return a.Id.String()
+	return a.actionID.String()
 }
 
 // HandlePacket implements core.ActionController.

--- a/testutil/mocks/controllers.go
+++ b/testutil/mocks/controllers.go
@@ -31,15 +31,15 @@ import (
 var _ types.ControllerForwarding = &ForwardingController{}
 
 type ForwardingController struct {
-	protocolID core.ProtocolID
+	id core.ProtocolID
 }
 
 func (o *ForwardingController) ID() core.ProtocolID {
-	return o.protocolID
+	return o.id
 }
 
 func (o *ForwardingController) Name() string {
-	return o.protocolID.String()
+	return o.id.String()
 }
 
 func (o *ForwardingController) HandlePacket(ctx context.Context, _ *types.ForwardingPacket) error {
@@ -53,15 +53,15 @@ func (o *ForwardingController) HandlePacket(ctx context.Context, _ *types.Forwar
 var _ types.ControllerAction = &NoOpActionController{}
 
 type NoOpActionController struct {
-	actionID core.ActionID
+	id core.ActionID
 }
 
 func (a *NoOpActionController) ID() core.ActionID {
-	return a.actionID
+	return a.id
 }
 
 func (a *NoOpActionController) Name() string {
-	return a.actionID.String()
+	return a.id.String()
 }
 
 func (a *NoOpActionController) HandlePacket(ctx context.Context, _ *types.ActionPacket) error {
@@ -75,15 +75,15 @@ func (a *NoOpActionController) HandlePacket(ctx context.Context, _ *types.Action
 var _ types.ControllerAdapter = &NoOpAdapterController{}
 
 type NoOpAdapterController struct {
-	Id core.ProtocolID
+	id core.ProtocolID
 }
 
 func (a *NoOpAdapterController) ID() core.ProtocolID {
-	return a.Id
+	return a.id
 }
 
 func (a *NoOpAdapterController) Name() string {
-	return a.Id.String()
+	return a.id.String()
 }
 
 func (a *NoOpAdapterController) ParsePayload(

--- a/testutil/mocks/controllers.go
+++ b/testutil/mocks/controllers.go
@@ -34,17 +34,14 @@ type ForwardingController struct {
 	protocolID core.ProtocolID
 }
 
-// ID implements core.ForwardingController.
 func (o *ForwardingController) ID() core.ProtocolID {
 	return o.protocolID
 }
 
-// Name implements core.ForwardingController.
 func (o *ForwardingController) Name() string {
 	return o.protocolID.String()
 }
 
-// HandlePacket implements core.ForwardingController.
 func (o *ForwardingController) HandlePacket(ctx context.Context, _ *types.ForwardingPacket) error {
 	if CheckIfFailing(ctx) {
 		return errors.New("error dispatching the forwarding packet")
@@ -59,17 +56,14 @@ type NoOpActionController struct {
 	actionID core.ActionID
 }
 
-// ID implements core.ActionController.
 func (a *NoOpActionController) ID() core.ActionID {
 	return a.actionID
 }
 
-// Name implements core.ActionController.
 func (a *NoOpActionController) Name() string {
 	return a.actionID.String()
 }
 
-// HandlePacket implements core.ActionController.
 func (a *NoOpActionController) HandlePacket(ctx context.Context, _ *types.ActionPacket) error {
 	if CheckIfFailing(ctx) {
 		return errors.New("error dispatching the action packet")
@@ -92,7 +86,6 @@ func (a *NoOpAdapterController) Name() string {
 	return a.Id.String()
 }
 
-// ParsePayload implements types.AdapterProtocol.
 func (a *NoOpAdapterController) ParsePayload(
 	_ core.ProtocolID,
 	bz []byte,

--- a/types/core/keys.go
+++ b/types/core/keys.go
@@ -36,8 +36,7 @@ const (
 var (
 	ModuleAddress = authtypes.NewModuleAddress(ModuleName)
 
-	dustCollectorName    = fmt.Sprintf("%s/%s", ModuleName, "dust_collector")
-	DustCollectorAddress = authtypes.NewModuleAddress(dustCollectorName)
+	DustCollectorName = fmt.Sprintf("%s/%s", ModuleName, "dust_collector")
 )
 
 // ====================================================================================================

--- a/types/expected_keepers.go
+++ b/types/expected_keepers.go
@@ -46,5 +46,9 @@ type BankKeeperAdapter interface {
 	// Queries
 	GetAllBalances(ctx context.Context, addr sdk.AccAddress) sdk.Coins
 	// Txs
-	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(
+		ctx context.Context,
+		senderModule, recipientModule string,
+		amt sdk.Coins,
+	) error
 }

--- a/types/expected_keepers.go
+++ b/types/expected_keepers.go
@@ -46,5 +46,5 @@ type BankKeeperAdapter interface {
 	// Queries
 	GetAllBalances(ctx context.Context, addr sdk.AccAddress) sdk.Coins
 	// Txs
-	SendCoins(ctx context.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(ctx context.Context, sender, recipient string, amt sdk.Coins) error
 }

--- a/types/expected_keepers.go
+++ b/types/expected_keepers.go
@@ -46,5 +46,5 @@ type BankKeeperAdapter interface {
 	// Queries
 	GetAllBalances(ctx context.Context, addr sdk.AccAddress) sdk.Coins
 	// Txs
-	SendCoinsFromModuleToModule(ctx context.Context, sender, recipient string, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
 }


### PR DESCRIPTION
This PR replaces the generic `SendCoins` used to send Orbiter module balance to the dust collector with the `SendCoinsFromModuleToModule` to check that the dust collector is correctly registered as a module. 

Moreover, the external transfer of funds to the collector is blocked adding it in the `blocked_module_accounts_override`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Orbiter balance clearing now performs transfers between module accounts using module identifiers instead of address-based calls.
* **Chores**
  * Added a new "orbiter/dust_collector" module account to app configuration and included it in the bank's blocked accounts.
* **Tests**
  * Updated test utilities and mocks to support module-to-module transfers; adjusted e2e test references.

No user-facing behavior changes are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->