### PR TITLE
chore: rename controllers to use correct grammar

### DIFF
--- a/controller/action/fee.go
+++ b/controller/action/fee.go
@@ -36,7 +36,7 @@ import (
 	"github.com/noble-assets/orbiter/types/core"
 )
 
-var _ types.ControllerAction = &FeeController{}
+var _ types.ActionController = &FeeController{}
 
 // FeeController is the controller to execute
 // fee payment action.

--- a/controller/adapter/ibc.go
+++ b/controller/adapter/ibc.go
@@ -31,7 +31,7 @@ import (
 	"github.com/noble-assets/orbiter/types/core"
 )
 
-var _ types.ControllerAdapter = &IBCAdapter{}
+var _ types.AdapterController = &IBCAdapter{}
 
 // IBCAdapter is the type component in charge of adapting the
 // memo of an IBC ICS20 transfer to the common payload type

--- a/controller/forwarding/cctp.go
+++ b/controller/forwarding/cctp.go
@@ -35,7 +35,7 @@ import (
 	"github.com/noble-assets/orbiter/types/core"
 )
 
-var _ types.ControllerForwarding = &CCTPController{}
+var _ types.ForwardingController = &CCTPController{}
 
 // CCTPController is the forwarding controller to perform
 // a CCTP transfer.

--- a/controller/forwarding/hyperlane.go
+++ b/controller/forwarding/hyperlane.go
@@ -37,7 +37,7 @@ import (
 	"github.com/noble-assets/orbiter/types/core"
 )
 
-var _ types.ControllerForwarding = &HyperlaneController{}
+var _ types.ForwardingController = &HyperlaneController{}
 
 // HyperlaneController is the forwarding controller for the Hyperlane protocol.
 type HyperlaneController struct {
@@ -89,7 +89,7 @@ func (c *HyperlaneController) Validate() error {
 	return nil
 }
 
-// HandlePacket implements types.ControllerForwarding.
+// HandlePacket implements types.ForwardingController.
 func (c *HyperlaneController) HandlePacket(
 	ctx context.Context,
 	packet *types.ForwardingPacket,

--- a/keeper/component/adapter/adapter.go
+++ b/keeper/component/adapter/adapter.go
@@ -38,7 +38,7 @@ import (
 	"github.com/noble-assets/orbiter/types/router"
 )
 
-type AdapterRouter = *router.Router[core.ProtocolID, types.ControllerAdapter]
+type AdapterRouter = *router.Router[core.ProtocolID, types.AdapterController]
 
 var _ types.Adapter = &Adapter{}
 
@@ -74,7 +74,7 @@ func New(
 	adaptersKeeper := Adapter{
 		logger:       logger.With(core.ComponentPrefix, core.AdapterName),
 		eventService: eventService,
-		router:       router.New[core.ProtocolID, types.ControllerAdapter](),
+		router:       router.New[core.ProtocolID, types.AdapterController](),
 		bankKeeper:   bankKeeper,
 		dispatcher:   dispatcher,
 		params: collections.NewItem(

--- a/keeper/component/adapter/adapter.go
+++ b/keeper/component/adapter/adapter.go
@@ -71,7 +71,7 @@ func New(
 		return nil, core.ErrNilPointer.Wrap("logger cannot be nil")
 	}
 
-	adaptersKeeper := Adapter{
+	adapter := Adapter{
 		logger:       logger.With(core.ComponentPrefix, core.AdapterName),
 		eventService: eventService,
 		router:       router.New[core.ProtocolID, types.AdapterController](),
@@ -85,7 +85,7 @@ func New(
 		),
 	}
 
-	return &adaptersKeeper, adaptersKeeper.Validate()
+	return &adapter, adapter.Validate()
 }
 
 // Validate returns an error if the component instance is not valid.

--- a/keeper/component/executor/executor.go
+++ b/keeper/component/executor/executor.go
@@ -36,7 +36,7 @@ import (
 	"github.com/noble-assets/orbiter/types/router"
 )
 
-type ActionRouter = *router.Router[core.ActionID, types.ControllerAction]
+type ActionRouter = *router.Router[core.ActionID, types.ActionController]
 
 var _ types.Executor = &Executor{}
 
@@ -69,7 +69,7 @@ func New(
 	executor := Executor{
 		logger:       logger.With(core.ComponentPrefix, core.ExecutorName),
 		eventService: eventService,
-		router:       router.New[core.ActionID, types.ControllerAction](),
+		router:       router.New[core.ActionID, types.ActionController](),
 		PausedActions: collections.NewKeySet(
 			sb,
 			core.PausedActionsPrefix,

--- a/keeper/component/forwarder/forwarder.go
+++ b/keeper/component/forwarder/forwarder.go
@@ -36,7 +36,7 @@ import (
 	router "github.com/noble-assets/orbiter/types/router"
 )
 
-type ForwardingRouter = router.Router[core.ProtocolID, types.ControllerForwarding]
+type ForwardingRouter = router.Router[core.ProtocolID, types.ForwardingController]
 
 var _ types.Forwarder = &Forwarder{}
 
@@ -72,7 +72,7 @@ func New(
 		logger:       logger.With(core.ComponentPrefix, core.ForwarderName),
 		eventService: eventService,
 		bankKeeper:   bankKeeper,
-		router:       router.New[core.ProtocolID, types.ControllerForwarding](),
+		router:       router.New[core.ProtocolID, types.ForwardingController](),
 		pausedCrossChains: collections.NewKeySet(
 			sb,
 			core.PausedCrossChainsPrefix,

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -177,7 +177,7 @@ func (k *Keeper) Adapter() *adaptercomp.Adapter {
 	return k.adapter
 }
 
-func (k *Keeper) SetForwardingControllers(controllers ...types.ControllerForwarding) {
+func (k *Keeper) SetForwardingControllers(controllers ...types.ForwardingController) {
 	router := k.forwarder.Router()
 	for _, c := range controllers {
 		if err := router.AddRoute(c); err != nil {
@@ -189,7 +189,7 @@ func (k *Keeper) SetForwardingControllers(controllers ...types.ControllerForward
 	}
 }
 
-func (k *Keeper) SetActionControllers(controllers ...types.ControllerAction) {
+func (k *Keeper) SetActionControllers(controllers ...types.ActionController) {
 	router := k.executor.Router()
 	for _, c := range controllers {
 		if err := router.AddRoute(c); err != nil {
@@ -201,7 +201,7 @@ func (k *Keeper) SetActionControllers(controllers ...types.ControllerAction) {
 	}
 }
 
-func (k *Keeper) SetAdapterControllers(controllers ...types.ControllerAdapter) {
+func (k *Keeper) SetAdapterControllers(controllers ...types.AdapterController) {
 	router := k.adapter.Router()
 	for _, c := range controllers {
 		if err := router.AddRoute(c); err != nil {

--- a/testutil/mocks/controllers.go
+++ b/testutil/mocks/controllers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/noble-assets/orbiter/types/core"
 )
 
-var _ types.ControllerForwarding = &ForwardingController{}
+var _ types.ForwardingController = &ForwardingController{}
 
 type ForwardingController struct {
 	id core.ProtocolID
@@ -50,7 +50,7 @@ func (o *ForwardingController) HandlePacket(ctx context.Context, _ *types.Forwar
 	return nil
 }
 
-var _ types.ControllerAction = &NoOpActionController{}
+var _ types.ActionController = &NoOpActionController{}
 
 type NoOpActionController struct {
 	id core.ActionID
@@ -72,7 +72,7 @@ func (a *NoOpActionController) HandlePacket(ctx context.Context, _ *types.Action
 	return nil
 }
 
-var _ types.ControllerAdapter = &NoOpAdapterController{}
+var _ types.AdapterController = &NoOpAdapterController{}
 
 type NoOpAdapterController struct {
 	id core.ProtocolID

--- a/types/component.go
+++ b/types/component.go
@@ -42,7 +42,7 @@ type Authorizer interface {
 type Forwarder interface {
 	Loggable
 	PacketHandler[*ForwardingPacket]
-	router.RouterProvider[core.ProtocolID, ControllerForwarding]
+	router.RouterProvider[core.ProtocolID, ForwardingController]
 	Pause(context.Context, core.ProtocolID, []string) error
 	Unpause(context.Context, core.ProtocolID, []string) error
 }
@@ -52,7 +52,7 @@ type Forwarder interface {
 type Executor interface {
 	Loggable
 	PacketHandler[*ActionPacket]
-	router.RouterProvider[core.ActionID, ControllerAction]
+	router.RouterProvider[core.ActionID, ActionController]
 	Pause(context.Context, core.ActionID) error
 	Unpause(context.Context, core.ActionID) error
 }
@@ -69,5 +69,5 @@ type Dispatcher interface {
 type Adapter interface {
 	Loggable
 	PayloadAdapter
-	router.RouterProvider[core.ProtocolID, ControllerAdapter]
+	router.RouterProvider[core.ProtocolID, AdapterController]
 }

--- a/types/controller.go
+++ b/types/controller.go
@@ -25,23 +25,23 @@ import (
 	"github.com/noble-assets/orbiter/types/router"
 )
 
-// ControllerForwarding defines the behavior a forwarding packet
+// ForwardingController defines the behavior a forwarding packet
 // controller has to implement.
-type ControllerForwarding interface {
+type ForwardingController interface {
 	Controller[core.ProtocolID]
 	PacketHandler[*ForwardingPacket]
 }
 
-// ControllerAction defines the behavior an action packet
+// ActionController defines the behavior an action packet
 // controller has to implement.
-type ControllerAction interface {
+type ActionController interface {
 	Controller[core.ActionID]
 	PacketHandler[*ActionPacket]
 }
 
-// ControllerAdapter defines the behavior expected from a specific
+// AdapterController defines the behavior expected from a specific
 // protocol adapter.
-type ControllerAdapter interface {
+type AdapterController interface {
 	Controller[core.ProtocolID]
 	PayloadParser
 }


### PR DESCRIPTION
This PR updates the names of the controller implementations to use correct grammar.
