### PR TITLE
chore: add validate method to forwarding attributes interface

### DIFF
--- a/testutil/testdata/testdata.go
+++ b/testutil/testdata/testdata.go
@@ -30,3 +30,5 @@ var (
 func (a *TestForwardingAttr) CounterpartyID() string {
 	return a.Planet
 }
+
+func (a *TestForwardingAttr) Validate() error { return nil }

--- a/types/core/attributes.go
+++ b/types/core/attributes.go
@@ -36,6 +36,6 @@ type ForwardingAttributes interface {
 	proto.Message
 	// CounterpartyID returns the destination chain identifier.
 	CounterpartyID() string
-	// Validate the attributes.
+	// Validate returns an error if the attributes are not valid.
 	Validate() error
 }

--- a/types/core/attributes.go
+++ b/types/core/attributes.go
@@ -34,6 +34,8 @@ type ActionAttributes interface {
 // attribute type has to implement.
 type ForwardingAttributes interface {
 	proto.Message
-	// Returns the destination chain identifier.
+	// CounterpartyID returns the destination chain identifier.
 	CounterpartyID() string
+	// Validate the attributes.
+	Validate() error
 }


### PR DESCRIPTION
This PR adds the `Validate()` method to the `ForwardingAttributes` interface, to enforce that all implementations of the interface can be validated.

This is part of the changes that should be introduced in separate PRs as discussed on #45.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a validation hook for forwarding attributes; no behavioral changes expected for end-users in this release.

- Documentation
  - Clarified wording for the counterparty identifier to better reflect it is the destination chain identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->