### PR TITLE
fix(ci): use main branch after merge

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -25,7 +25,7 @@ jobs:
           tag: local # emulate local environment for consistency in interchaintest cases
           tar-export-path: ${{ env.TAR_PATH }} # export a tarball that can be uploaded as an artifact for the e2e jobs
           platform: linux/amd64 # test runner architecture only
-          git-ref: ${{ github.head_ref }} # source code ref
+          git-ref: ${{ github.head_ref || github.ref_name}} # source code ref
           # Heighliner fork supporting Go v1.24
           heighliner-owner: 'noble-assets'
           heighliner-tag: 'v1.7.3'


### PR DESCRIPTION
After merging a PR, the heighliner in the CI uses the tag as a git reference for the image to build. We want to use `main` or the e2e fail because use a wrong source for the binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved resilience of the e2e testing workflow by adding fallback logic for source code reference determination when standard reference is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->